### PR TITLE
Fix numpy to what version networkx==2.4 expects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jsonlines==1.2.0
 networkx==2.4
+numpy==1.20.1
 rhasspy-nlu~=0.3.0
 snips-nlu==0.20.2


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for explanation